### PR TITLE
feat: add domain event bus for stomp state changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,108 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+DMX Stomps is a DMX and MIDI control system with a web interface. It allows users to toggle "stomps" (lighting effects) via a React frontend that communicates with a FastAPI backend, which controls DMX lighting hardware via OLA (Open Lighting Architecture).
+
+## Development Commands
+
+### Installation
+```bash
+# Create Python virtual environment
+python -m venv ./backend/.venv
+chmod +x ./backend/.venv/bin/activate
+
+# Install all dependencies
+npm run dev:install
+```
+
+### Running the Application
+```bash
+# Activate Python virtual environment first
+source ./backend/.venv/bin/activate
+
+# Run backend only (FastAPI on port 8000)
+npm run backend:dev
+
+# Run frontend only (Vite dev server)
+npm run frontend:dev
+```
+
+### Testing
+```bash
+# Backend tests (from root or with venv activated)
+npm run backend:test
+# Or: cd backend && pytest -q
+
+# Frontend tests
+cd frontend && npm run test
+```
+
+### Building
+```bash
+# Frontend production build
+npm run frontend:build
+
+# Preview production build
+npm run frontend:preview
+```
+
+## Architecture
+
+This is a **monorepo** with two main components:
+
+### Backend (Python/FastAPI)
+- **Framework**: FastAPI with uvicorn
+- **Architecture**: Clean Architecture / DDD-inspired
+  - `domain/`: Core business entities (`Stomp`, `StompRepository` interface)
+  - `infrastructure/`: Concrete implementations (`InMemoryStompRepository`, `DmxDeamon`)
+  - `commands/`: Command pattern for operations (`ToggleStompCommand`)
+  - `commands/handlers/`: Command handlers execute business logic
+  - `dmx/`: DMX hardware communication via OLA
+  - `midi/`: MIDI input handling via mido/python-rtmidi
+  - `api.py`: FastAPI app with REST endpoints and dependency injection
+
+- **Key Patterns**:
+  - Repository pattern for data access
+  - Command/Handler pattern for operations
+  - Singleton pattern for `DmxDeamon`
+  - FastAPI `Depends()` for dependency injection
+
+- **API Endpoints**:
+  - `GET /stomps` - List all stomps
+  - `PUT /stomps/{id}` - Toggle stomp state (on/off)
+  - `POST /deamon/start` - Start DMX daemon
+  - `POST /deamon/stop` - Stop DMX daemon
+
+### Frontend (React/TypeScript)
+- **Framework**: React 19 with TypeScript, Vite
+- **State Management**: TanStack Query (React Query) for server state
+- **Structure**:
+  - `src/api/stomps.ts`: API client functions
+  - `src/App.tsx`: Main component with stomp list and toggle buttons
+  - Tests use Vitest + React Testing Library
+
+## Testing Guidelines
+
+When writing tests, follow these project-specific conventions:
+- Use `// Arrange`, `// Act`, `// Assert` comments to structure tests
+- Use BDD style when possible
+- Don't over-factor tests unless explicitly requested
+- Name the system under test `sut`
+- **Important**: When writing tests, don't implement the actual code unless asked
+
+## Code Style
+
+- **No comments**: Code should be self-explanatory
+- **Short functions**: Avoid long functions
+- **Low cyclomatic complexity**: Keep logic simple and readable
+- **No emojis** in code unless explicitly requested
+
+## Important Notes
+
+- The backend uses a **singleton pattern** for `DmxDeamon` to ensure only one instance manages DMX hardware
+- CORS is currently configured with `allow_origins=["*"]` - configure properly for production
+- The `InMemoryStompRepository` is the current implementation; production may need persistent storage
+- MIDI handler (`midi/handler.py`) is partially implemented and hardcoded to "MidiKeys" port

--- a/backend/domain/__init__.py
+++ b/backend/domain/__init__.py
@@ -1,4 +1,7 @@
 from .stomp import Stomp
 from .stomp_repository import StompRepository
+from .event_bus import EventBus
+from .domain_event import DomainEvent
+from .stomp_state_changed_event import StompStateChangedEvent
 
-__all__ = ['Stomp', 'StompRepository']
+__all__ = ['Stomp', 'StompRepository', 'EventBus', 'DomainEvent', 'StompStateChangedEvent']

--- a/backend/domain/domain_event.py
+++ b/backend/domain/domain_event.py
@@ -1,0 +1,10 @@
+from abc import ABC
+from datetime import datetime
+from typing import Any
+
+class DomainEvent(ABC):
+    def __init__(self):
+        self.occurred_at = datetime.now()
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(occurred_at={self.occurred_at})"

--- a/backend/domain/event_bus.py
+++ b/backend/domain/event_bus.py
@@ -1,0 +1,25 @@
+from typing import Callable, Dict, List, Type
+from domain.domain_event import DomainEvent
+
+class EventBus:
+    _instance = None
+
+    def __new__(cls):
+        if not isinstance(cls._instance, cls):
+            cls._instance = object.__new__(cls)
+            cls._instance._handlers = {}
+        return cls._instance
+
+    def subscribe(self, event_type: Type[DomainEvent], handler: Callable[[DomainEvent], None]) -> None:
+        if event_type not in self._handlers:
+            self._handlers[event_type] = []
+        self._handlers[event_type].append(handler)
+
+    def publish(self, event: DomainEvent) -> None:
+        event_type = type(event)
+        if event_type in self._handlers:
+            for handler in self._handlers[event_type]:
+                handler(event)
+
+    def clear_handlers(self) -> None:
+        self._handlers = {}

--- a/backend/domain/stomp.py
+++ b/backend/domain/stomp.py
@@ -1,8 +1,12 @@
+from domain.event_bus import EventBus
+from domain.stomp_state_changed_event import StompStateChangedEvent
+
 class Stomp:
-    def __init__(self, id, name, state):
+    def __init__(self, id, name, state, event_bus: EventBus = None):
         self._id = id
         self.name = name
         self._state = state
+        self._event_bus = event_bus or EventBus()
 
     @property
     def id(self):
@@ -13,4 +17,6 @@ class Stomp:
         return self._state
 
     def updateState(self, value):
+        old_state = self._state
         self._state = value
+        self._event_bus.publish(StompStateChangedEvent(self._id, old_state, value))

--- a/backend/domain/stomp_state_changed_event.py
+++ b/backend/domain/stomp_state_changed_event.py
@@ -1,0 +1,11 @@
+from domain.domain_event import DomainEvent
+
+class StompStateChangedEvent(DomainEvent):
+    def __init__(self, stomp_id: str, old_state: str, new_state: str):
+        super().__init__()
+        self.stomp_id = stomp_id
+        self.old_state = old_state
+        self.new_state = new_state
+
+    def __repr__(self):
+        return f"StompStateChangedEvent(stomp_id={self.stomp_id}, old_state={self.old_state}, new_state={self.new_state}, occurred_at={self.occurred_at})"

--- a/backend/domain/test_event_bus.py
+++ b/backend/domain/test_event_bus.py
@@ -1,0 +1,69 @@
+import pytest
+from domain.event_bus import EventBus
+from domain.domain_event import DomainEvent
+from domain.stomp_state_changed_event import StompStateChangedEvent
+
+class TestEventBus:
+    def setup_method(self):
+        sut = EventBus()
+        sut.clear_handlers()
+
+    def test_should_publish_event_to_subscribed_handler(self):
+        # Arrange
+        sut = EventBus()
+        received_events = []
+
+        def handler(event):
+            received_events.append(event)
+
+        sut.subscribe(StompStateChangedEvent, handler)
+        event = StompStateChangedEvent("stomp1", "off", "on")
+
+        # Act
+        sut.publish(event)
+
+        # Assert
+        assert len(received_events) == 1
+        assert received_events[0] == event
+
+    def test_should_publish_event_to_multiple_handlers(self):
+        # Arrange
+        sut = EventBus()
+        handler1_calls = []
+        handler2_calls = []
+
+        sut.subscribe(StompStateChangedEvent, lambda e: handler1_calls.append(e))
+        sut.subscribe(StompStateChangedEvent, lambda e: handler2_calls.append(e))
+        event = StompStateChangedEvent("stomp1", "off", "on")
+
+        # Act
+        sut.publish(event)
+
+        # Assert
+        assert len(handler1_calls) == 1
+        assert len(handler2_calls) == 1
+
+    def test_should_not_call_handler_for_different_event_type(self):
+        # Arrange
+        sut = EventBus()
+        received_events = []
+
+        class OtherEvent(DomainEvent):
+            pass
+
+        sut.subscribe(StompStateChangedEvent, lambda e: received_events.append(e))
+        event = OtherEvent()
+
+        # Act
+        sut.publish(event)
+
+        # Assert
+        assert len(received_events) == 0
+
+    def test_should_work_as_singleton(self):
+        # Arrange
+        bus1 = EventBus()
+        bus2 = EventBus()
+
+        # Assert
+        assert bus1 is bus2


### PR DESCRIPTION
Implemented a domain event bus pattern to enable event-driven architecture when stomp states change. This allows for loose coupling between components and makes it easier to add side effects when stomps are toggled.

Changes:
- Added DomainEvent base class for all domain events
- Created StompStateChangedEvent for stomp state transitions
- Implemented EventBus singleton with subscribe/publish pattern
- Updated Stomp entity to publish events on state changes
- Added comprehensive test coverage for event bus
- Created CLAUDE.md documentation for future AI assistance